### PR TITLE
Map user 

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -47,7 +47,7 @@ ifneq "$(shell $(CC) --version | grep clang)" ""
   endif
 endif
 
-SOURCES := config.c http.c utils.c tty.c pam_weblogin.c
+SOURCES := config.c http.c utils.c tty.c pam_weblogin.c user_map.c
 OBJS := $(SOURCES:%.c=%.o)
 
 CFLAGS += -I..
@@ -66,7 +66,8 @@ config.o: config.c config.h tty.h defs.h
 http.o: http.c http.h tty.h defs.h
 utils.o: utils.c utils.h tty.h defs.h
 tty.o: tty.c utils.h defs.h
-pam_weblogin.o: pam_weblogin.c config.h http.h utils.h tty.h defs.h
+uaer_map.o: user_map.c user_map.h config.h
+pam_weblogin.o: pam_weblogin.c config.h http.h utils.h tty.h defs.h user_map.h
 
 pam_weblogin.so: $(OBJS) ../json-parser-build/libjsonparser.a
 	$(CC) $(LDFLAGS) -shared -o $@ $^ -lcurl -lpam -lm

--- a/src/config.h
+++ b/src/config.h
@@ -9,6 +9,7 @@ typedef struct
 	char *url;
 	char *token;
 	char *attribute;
+	char *username;
 	unsigned int cache_duration;
 	unsigned int retries;
 } Config;

--- a/src/user_map.c
+++ b/src/user_map.c
@@ -29,19 +29,11 @@ int user_map(const char *name, Config *cfg)
   FILE *f;
   int line = 0;
 
-  /*
-  SYSLOG_DEBUG(pamh, LOG_DEBUG, "Opening file '%s'.\n", FILENAME);
-  */
-
   f= fopen(FILENAME, "r");
   if (f == NULL)
   {
     return 0;
   }
-
-  /*
-  SYSLOG_DEBUG(pamh, LOG_DEBUG, "Incoming username '%s'.\n", username);
-  */
 
   while (fgets(buf, sizeof(buf), f) != NULL)
   {
@@ -73,9 +65,6 @@ int user_map(const char *name, Config *cfg)
     skip(isalnum(*s) || (*s == '_') || (*s == '.') || (*s == '-') ||
          (*s == '$'));
     end_to= s;
-    /* HvB
-    if (end_to == to) goto syntax_error;
-    */
 
     *end_from= *end_to= 0;
 

--- a/src/user_map.c
+++ b/src/user_map.c
@@ -1,0 +1,125 @@
+/*
+  Pam module to change user names arbitrarily in the pam stack.
+
+  Compile as
+
+     gcc pam_user_map.c -shared -lpam -fPIC -o pam_user_map.so
+
+  Install as appropriate (for example, in /lib/security/).
+  Add to your /etc/pam.d/mysql (preferably, at the end) this line:
+=========================================================
+auth            required        pam_user_map.so
+=========================================================
+
+  And create /etc/security/user_map.conf with the desired mapping
+  in the format:  orig_user_name: mapped_user_name
+                  @user's_group_name: mapped_user_name
+=========================================================
+#comments and empty lines are ignored
+john: jack
+bob:  admin
+top:  accounting
+@group_ro: readonly
+=========================================================
+
+If something doesn't work as expected you can get verbose
+comments with the 'debug' option like this
+=========================================================
+auth            required        pam_user_map.so debug
+=========================================================
+These comments are written to the syslog as 'authpriv.debug'
+and usually end up in /var/log/secure file.
+*/
+
+#include "defs.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <ctype.h>
+#include <string.h>
+#include <syslog.h>
+
+
+#include "config.h"
+#include "tty.h"
+#include "user_map.h"
+
+
+int user_map(const char *name, Config *cfg)
+{
+  char buf[256];
+  FILE *f;
+  int line = 0;
+
+  /*
+  SYSLOG_DEBUG(pamh, LOG_DEBUG, "Opening file '%s'.\n", FILENAME);
+  */
+
+  f= fopen(FILENAME, "r");
+  if (f == NULL)
+  {
+    return 0;
+  }
+
+  /*
+  SYSLOG_DEBUG(pamh, LOG_DEBUG, "Incoming username '%s'.\n", username);
+  */
+
+  while (fgets(buf, sizeof(buf), f) != NULL)
+  {
+    char *s= buf, *from, *to, *end_from, *end_to;
+    int cmp_result;
+
+    line++;
+    log_message(LOG_DEBUG, "HvB '%s'n", buf);
+
+    skip(isspace(*s));
+    if (*s == '#' || *s == 0) continue;
+
+    from= s;
+    skip(isalnum(*s) || (*s == '_') || (*s == '.') || (*s == '-') ||
+         (*s == '$') || (*s == '\\') || (*s == '/'));
+    end_from= s;
+    skip(isspace(*s));
+
+    if (end_from == from || *s++ != ':')
+    {
+       log_message(LOG_ERR, "Syntax error at %s:%d", FILENAME, line);
+       fclose(f);
+       return 0;
+    }
+
+    skip(isspace(*s));
+    log_message(LOG_DEBUG, "HvB char '%s'n", s);
+    to= s;
+    skip(isalnum(*s) || (*s == '_') || (*s == '.') || (*s == '-') ||
+         (*s == '$'));
+    end_to= s;
+    /* HvB
+    if (end_to == to) goto syntax_error;
+    */
+
+    *end_from= *end_to= 0;
+
+    cmp_result= (strcmp(name, from) == 0);
+    log_message(LOG_DEBUG, "Check if username '%s': %s\n",
+                                    from, cmp_result ? "YES":"NO");
+
+    if (cmp_result)
+    {
+      log_message(LOG_INFO, "HvB name: %s\n", name);
+      log_message(LOG_INFO, "HvB from: %s\n", from);
+      log_message(LOG_DEBUG,"User mapped as '%s'\n", to);
+      cfg->username = strdup(to);
+      fclose(f);
+      return 1;
+    }
+    else
+    {
+      cfg->username = strdup(name);
+    }
+  }
+
+  fclose(f);
+  return 0;
+}

--- a/src/user_map.c
+++ b/src/user_map.c
@@ -1,33 +1,11 @@
 /*
-  Pam module to change user names arbitrarily in the pam stack.
-
-  Compile as
-
-     gcc pam_user_map.c -shared -lpam -fPIC -o pam_user_map.so
-
-  Install as appropriate (for example, in /lib/security/).
-  Add to your /etc/pam.d/mysql (preferably, at the end) this line:
-=========================================================
-auth            required        pam_user_map.so
-=========================================================
-
-  And create /etc/security/user_map.conf with the desired mapping
-  in the format:  orig_user_name: mapped_user_name
-                  @user's_group_name: mapped_user_name
+if  create /etc/security/user_map.conf with the desired mapping
 =========================================================
 #comments and empty lines are ignored
-john: jack
-bob:  admin
-top:  accounting
-@group_ro: readonly
+bastiaan: basvandervlies
+dennis: joedoe
 =========================================================
 
-If something doesn't work as expected you can get verbose
-comments with the 'debug' option like this
-=========================================================
-auth            required        pam_user_map.so debug
-=========================================================
-These comments are written to the syslog as 'authpriv.debug'
 and usually end up in /var/log/secure file.
 */
 

--- a/src/user_map.h
+++ b/src/user_map.h
@@ -1,0 +1,9 @@
+#ifndef USER_MAP_H
+#define USER_MAP_H
+
+#define FILENAME "/etc/security/user_map.conf"
+#define skip(what) while (*s && (what)) s++
+
+int  user_map(const char *name, Config *cfg);
+
+#endif /* USER_MAP_H */


### PR DESCRIPTION
This is POC so we can run in a mixed environment where we can map our logins to SRAM username. For example the user `bas` is known in our CUA environment and has a home directory, uid, gid, ...

This is user is not known in the SRAM environment. But I want to use `pam-weblogin` for authentication. Then we create
a mapping file:
```
bas:  <username_in_sram>
```

So pam-weblogin will use `<username_in_sram>` for authentication when we ssh:
 * ssh bas@<login_node> 

and if there is no mapping then given username is used in this example `jaap`
 * ssh jaap@<ogin-node>

