### PR TITLE
Fine-tune the deb builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -259,7 +259,7 @@ jobs:
           echo "
             FROM ${{matrix.container}}
             RUN apt update; apt upgrade -y
-            RUN apt-get install -y git build-essential libpam0g-dev libcurl4-openssl-dev
+            RUN apt-get install -y build-essential libpam0g-dev libcurl4-openssl-dev
             RUN gcc --version
           " > Dockerfile;
           docker build -f Dockerfile -t pwl-${{matrix.name}} .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -260,7 +260,7 @@ jobs:
           echo "
             FROM ${{matrix.container}}
             RUN apt update; apt upgrade -y
-            RUN apt-get install -y build-essential libpam0g-dev libcurl4-openssl-dev
+            RUN apt-get install -y build-essential git libpam0g-dev libcurl4-openssl-dev
             RUN gcc --version
           " > Dockerfile;
           docker build -f Dockerfile -t pwl-${{matrix.name}} .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -235,7 +235,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: "debian10",  container: "debian:10"  }
+          - { name: "debian10",   container: "debian:10"    }
           - { name: "ubuntu2204", container: "ubuntu:22.04" }
     runs-on: "ubuntu-latest"
     steps:
@@ -272,13 +272,13 @@ jobs:
           " > Dockerfile;
           docker build -f Dockerfile -t pwl-${{matrix.name}} .
 
-      - name: build DEB package
+      - name: Build binaries
         run: >
           docker run -v `pwd`/pwl-checkout:/root/pam-weblogin \
                         pwl-${{matrix.name}} \
                         /bin/sh -c 'cd /root/pam-weblogin; make'
 
-      - name: debug
+      - name: Debug
         run: ls -laR pwl-checkout/src/*.so
 
       - name: Prepare build dir
@@ -294,12 +294,21 @@ jobs:
           Priority: optional
           Architecture: amd64
           Depends: libcurl3-gnutls, libpam0g
-          Maintainer: surf.nl
+          Maintainer: SURF <sram-support@surf.nl>
           Description: Pam weblogin module" > ${BUILD_DIR}/DEBIAN/control
           cat ${BUILD_DIR}/DEBIAN/control
-          dpkg-deb --build --root-owner-group ${BUILD_DIR}
 
-      - name: gather generated debs
+      - name: Build debs in container
+        run: |
+          docker run
+              -v `pwd``:/work/ \
+                pwl-${{matrix.name}} \
+                /bin/sh -c '
+                  cd /work &&
+                  dpkg-deb --build --root-owner-group ${BUILD_DIR}
+                '
+
+      - name: Gather generated debs
         run: |
           mkdir results
           cp *.deb results/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -299,14 +299,14 @@ jobs:
           cat ${BUILD_DIR}/DEBIAN/control
 
       - name: Build debs in container
-        run: |
-          docker run \
-              -v `pwd`:/work/ \
-                pwl-${{matrix.name}} \
-                /bin/sh -c '
+        run: >
+          docker run
+              -v `pwd`:/work/
+                pwl-${{matrix.name}}
+                /bin/sh -c "
                   cd /work &&
                   dpkg-deb --build --root-owner-group ${BUILD_DIR}
-                '
+                "
 
       - name: Gather generated debs
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -300,7 +300,7 @@ jobs:
 
       - name: Build debs in container
         run: |
-          docker run
+          docker run \
               -v `pwd``:/work/ \
                 pwl-${{matrix.name}} \
                 /bin/sh -c '

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -301,7 +301,7 @@ jobs:
       - name: Build debs in container
         run: |
           docker run \
-              -v `pwd``:/work/ \
+              -v `pwd`:/work/ \
                 pwl-${{matrix.name}} \
                 /bin/sh -c '
                   cd /work &&

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -231,6 +231,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - { name: "debian11",   container: "debian:11"    }
           - { name: "debian10",   container: "debian:10"    }
           - { name: "ubuntu2204", container: "ubuntu:22.04" }
     runs-on: "ubuntu-latest"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -281,7 +281,7 @@ jobs:
           mkdir -p ${BUILD_DIR}/lib/${BUILD_ARCH}/security/
           cp pwl-checkout/src/pam_weblogin.so ${BUILD_DIR}/lib/${BUILD_ARCH}/security/pam_weblogin.so
           cp pwl-checkout/pam-weblogin.conf.sample ${BUILD_DIR}/etc/pam-weblogin.conf
-          echo "Package: pam-weblogin
+          echo "Package: libpam-weblogin
           Version: ${PWL_VERSION}
           Section: custom
           Priority: optional

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -246,7 +246,7 @@ jobs:
           fi
           export PWL_VERSION=$(cat /tmp/version | tr -C 'a-zA-Z0-9.+' '-')
           echo PWL_VERSION=${PWL_VERSION} >> $GITHUB_ENV
-          echo BUILD_DIR=pam-weblogin_${PWL_VERSION}-${{matrix.name}}-1_amd64 >> $GITHUB_ENV
+          echo BUILD_DIR=libpam-weblogin_${PWL_VERSION}-${{matrix.name}}-1_amd64 >> $GITHUB_ENV
           echo SRC_FILE=pam-weblogin-${PWL_VERSION}.source.tar.xz  >> $GITHUB_ENV
           echo BUILD_ARCH=$(dpkg-architecture -q DEB_BUILD_MULTIARCH)  >> $GITHUB_ENV
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -248,6 +248,7 @@ jobs:
           echo PWL_VERSION=${PWL_VERSION} >> $GITHUB_ENV
           echo BUILD_DIR=pam-weblogin_${PWL_VERSION}-${{matrix.name}}-1_amd64 >> $GITHUB_ENV
           echo SRC_FILE=pam-weblogin-${PWL_VERSION}.source.tar.xz  >> $GITHUB_ENV
+          echo BUILD_ARCH=$(dpkg-architecture -q DEB_BUILD_MULTIARCH)  >> $GITHUB_ENV
 
       - name: Checkout
         uses: actions/checkout@v3
@@ -277,8 +278,8 @@ jobs:
         run: |
           mkdir -p ${BUILD_DIR}/DEBIAN
           mkdir -p ${BUILD_DIR}/etc/pam.d
-          mkdir -p ${BUILD_DIR}/usr/local/lib/security
-          cp pwl-checkout/src/pam_weblogin.so ${BUILD_DIR}/usr/local/lib/security/pam_weblogin.so
+          mkdir -p ${BUILD_DIR}/lib/${BUILD_ARCH}/security/
+          cp pwl-checkout/src/pam_weblogin.so ${BUILD_DIR}/lib/${BUILD_ARCH}/security/pam_weblogin.so
           cp pwl-checkout/pam-weblogin.conf.sample ${BUILD_DIR}/etc/pam-weblogin.conf
           echo "Package: pam-weblogin
           Version: ${PWL_VERSION}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,10 +154,6 @@ jobs:
           - { name: "fedora37", container: "fedora:37" }
     runs-on: "ubuntu-latest"
     steps:
-      - name: Docker caching
-        uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
-
       - name: Get tag/branch name
         run: |
           if [ "$GITHUB_REF_TYPE" = 'branch' ]; then
@@ -239,10 +235,6 @@ jobs:
           - { name: "ubuntu2204", container: "ubuntu:22.04" }
     runs-on: "ubuntu-latest"
     steps:
-      - name: Docker caching
-        uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
-
       - name: Get tag/branch name
         run: |
           if [ "$GITHUB_REF_TYPE" = 'branch' ]; then
@@ -299,10 +291,10 @@ jobs:
           cat ${BUILD_DIR}/DEBIAN/control
 
       - name: Build debs in container
-        run: >
-          docker run
-              -v `pwd`:/work/
-                pwl-${{matrix.name}}
+        run: |
+          docker run \
+              -v `pwd`:/work/ \
+                pwl-${{matrix.name}} \
                 /bin/sh -c "
                   cd /work &&
                   dpkg-deb --build --root-owner-group ${BUILD_DIR}


### PR DESCRIPTION
Compose the debs inside the container (rather than only building inside the container).  This fixes issues with newer deb versions as built on ubuntu-latest not working on debian 10.
Also fix the location of the binary inside the deb and adjust the package name for better consistency with aother pam packages.