### PR TITLE
Fix old gcc

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,21 +81,21 @@ jobs:
           - { os: ubuntu-20.04,  compiler: gcc,   version:   5 }
           - { os: ubuntu-20.04,  compiler: gcc,   version:   6 }
           - { os: ubuntu-20.04,  compiler: gcc,   version:   7 }
-#          - { os: ubuntu-20.04,  compiler: gcc,   version:   8 }
-#          - { os: ubuntu-22.04,  compiler: gcc,   version:   9 }
-#          - { os: ubuntu-22.04,  compiler: gcc,   version:  10 }
-#          - { os: ubuntu-22.04,  compiler: gcc,   version:  11 }
-#          - { os: ubuntu-22.04,  compiler: gcc,   version:  12 }
-#          - { os: ubuntu-20.04,  compiler: clang, version:   9 }
-#          - { os: ubuntu-20.04,  compiler: clang, version:  10 }
-#          - { os: ubuntu-20.04,  compiler: clang, version:  11 }
-#          - { os: ubuntu-20.04,  compiler: clang, version:  12 }
-#          - { os: ubuntu-22.04,  compiler: clang, version:  13 }
-#          - { os: ubuntu-22.04,  compiler: clang, version:  14 }
-#          - { os: ubuntu-22.04,  compiler: clang, version:  15 }
-#          - { os: macos-10.15,   compiler: native              }
-#          - { os: macos-11,      compiler: native              }
-#          - { os: macos-12,      compiler: native              }
+          - { os: ubuntu-20.04,  compiler: gcc,   version:   8 }
+          - { os: ubuntu-22.04,  compiler: gcc,   version:   9 }
+          - { os: ubuntu-22.04,  compiler: gcc,   version:  10 }
+          - { os: ubuntu-22.04,  compiler: gcc,   version:  11 }
+          - { os: ubuntu-22.04,  compiler: gcc,   version:  12 }
+          - { os: ubuntu-20.04,  compiler: clang, version:   9 }
+          - { os: ubuntu-20.04,  compiler: clang, version:  10 }
+          - { os: ubuntu-20.04,  compiler: clang, version:  11 }
+          - { os: ubuntu-20.04,  compiler: clang, version:  12 }
+          - { os: ubuntu-22.04,  compiler: clang, version:  13 }
+          - { os: ubuntu-22.04,  compiler: clang, version:  14 }
+          - { os: ubuntu-22.04,  compiler: clang, version:  15 }
+          - { os: macos-10.15,   compiler: native              }
+          - { os: macos-11,      compiler: native              }
+          - { os: macos-12,      compiler: native              }
 
     # set CC to 'cc' for MacOS and the (e.g.) clang-12 for Linux
     env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,15 +107,16 @@ jobs:
           sudo apt-get purge man-db
         if: runner.os == 'Linux'
 
-      - name: Install old gcc
+      - name: Add source for old gcc packages (ubuntu 18.04)
         run: |
           sudo tee "/etc/apt/sources.list.d/bionic.list" << EOF
-          deb http://archive.ubuntu.com/ubuntu bionic universe
-          deb http://security.ubuntu.com/ubuntu bionic-security main
+          deb http://azure.archive.ubuntu.com/ubuntu bionic universe
+          deb http://azure.archive.ubuntu.com/ubuntu bionic-security main
           EOF
           cat /etc/apt/sources.list
           ls -la /etc/apt/sources.list.d
           sudo apt update
+          sudo apt install -y libisl19
         if: runner.os == 'Linux' && matrix.compiler == 'gcc' && matrix.version < 7
 
       - name: Install gcc

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,7 +109,7 @@ jobs:
 
       - name: Install old gcc
         run: |
-          sudo cat > "/etc/apt/sources.list.d/bionic.list"<<EOF
+          sudo tee "/etc/apt/sources.list.d/bionic.list" << EOF
           deb http://archive.ubuntu.com/ubuntu bionic universe
           deb http://security.ubuntu.com/ubuntu bionic-security main
           EOF

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,25 +77,25 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { os: ubuntu-18.04,  compiler: gcc,   version: 4.8 }
-          - { os: ubuntu-18.04,  compiler: gcc,   version:   5 }
-          - { os: ubuntu-18.04,  compiler: gcc,   version:   6 }
+          - { os: ubuntu-20.04,  compiler: gcc,   version: 4.8 }
+          - { os: ubuntu-20.04,  compiler: gcc,   version:   5 }
+          - { os: ubuntu-20.04,  compiler: gcc,   version:   6 }
           - { os: ubuntu-20.04,  compiler: gcc,   version:   7 }
-          - { os: ubuntu-20.04,  compiler: gcc,   version:   8 }
-          - { os: ubuntu-22.04,  compiler: gcc,   version:   9 }
-          - { os: ubuntu-22.04,  compiler: gcc,   version:  10 }
-          - { os: ubuntu-22.04,  compiler: gcc,   version:  11 }
-          - { os: ubuntu-22.04,  compiler: gcc,   version:  12 }
-          - { os: ubuntu-20.04,  compiler: clang, version:   9 }
-          - { os: ubuntu-20.04,  compiler: clang, version:  10 }
-          - { os: ubuntu-20.04,  compiler: clang, version:  11 }
-          - { os: ubuntu-20.04,  compiler: clang, version:  12 }
-          - { os: ubuntu-22.04,  compiler: clang, version:  13 }
-          - { os: ubuntu-22.04,  compiler: clang, version:  14 }
-          - { os: ubuntu-22.04,  compiler: clang, version:  15 }
-          - { os: macos-10.15,   compiler: native              }
-          - { os: macos-11,      compiler: native              }
-          - { os: macos-12,      compiler: native              }
+#          - { os: ubuntu-20.04,  compiler: gcc,   version:   8 }
+#          - { os: ubuntu-22.04,  compiler: gcc,   version:   9 }
+#          - { os: ubuntu-22.04,  compiler: gcc,   version:  10 }
+#          - { os: ubuntu-22.04,  compiler: gcc,   version:  11 }
+#          - { os: ubuntu-22.04,  compiler: gcc,   version:  12 }
+#          - { os: ubuntu-20.04,  compiler: clang, version:   9 }
+#          - { os: ubuntu-20.04,  compiler: clang, version:  10 }
+#          - { os: ubuntu-20.04,  compiler: clang, version:  11 }
+#          - { os: ubuntu-20.04,  compiler: clang, version:  12 }
+#          - { os: ubuntu-22.04,  compiler: clang, version:  13 }
+#          - { os: ubuntu-22.04,  compiler: clang, version:  14 }
+#          - { os: ubuntu-22.04,  compiler: clang, version:  15 }
+#          - { os: macos-10.15,   compiler: native              }
+#          - { os: macos-11,      compiler: native              }
+#          - { os: macos-12,      compiler: native              }
 
     # set CC to 'cc' for MacOS and the (e.g.) clang-12 for Linux
     env:
@@ -106,6 +106,16 @@ jobs:
         run: |
           sudo apt-get purge man-db
         if: runner.os == 'Linux'
+
+      - name: Install old gcc
+        run: |
+          sudo cat > "/etc/apt/sources.list.d/bionic.list"<<EOF
+          deb http://archive.ubuntu.com/ubuntu bionic universe
+          deb http://security.ubuntu.com/ubuntu bionic-security main
+          EOF
+          cat /etc/sources.list
+          sudo apt update
+        if: runner.os == 'Linux' && matrix.compiler == 'gcc' && matrix.version < 7
 
       - name: Install gcc
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,7 +113,8 @@ jobs:
           deb http://archive.ubuntu.com/ubuntu bionic universe
           deb http://security.ubuntu.com/ubuntu bionic-security main
           EOF
-          cat /etc/sources.list
+          cat /etc/apt/sources.list
+          ls -la /etc/apt/sources.list.d
           sudo apt update
         if: runner.os == 'Linux' && matrix.compiler == 'gcc' && matrix.version < 7
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,13 +110,12 @@ jobs:
       - name: Add source for old gcc packages (ubuntu 18.04)
         run: |
           sudo tee "/etc/apt/sources.list.d/bionic.list" << EOF
-          deb http://azure.archive.ubuntu.com/ubuntu bionic universe
-          deb http://azure.archive.ubuntu.com/ubuntu bionic-security main
+          deb http://azure.archive.ubuntu.com/ubuntu bionic main universe
+          deb http://azure.archive.ubuntu.com/ubuntu bionic-security main universe
           EOF
           cat /etc/apt/sources.list
           ls -la /etc/apt/sources.list.d
           sudo apt update
-          sudo apt install -y libisl19
         if: runner.os == 'Linux' && matrix.compiler == 'gcc' && matrix.version < 7
 
       - name: Install gcc


### PR DESCRIPTION
Add ubuntu 18.04 sources for old gcc build, but use am ubuntu 20.04 VM on GH actions.