### PR TITLE
Add cache_per_rhost configuration flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ token = <replace with SRAM API TOKEN for your service>
 retries = 3
 attribute = email
 cache_duration = 30
+#cache_per_rhost
 verify = /etc/ssl/ca.crt
 ```
 
@@ -103,6 +104,7 @@ verify = /etc/ssl/ca.crt
 -   `token` is the complete HTTP `Authorization` header, including `Bearer`
 -   `retries` is the number of verification code retries allowed
 -   `cache_duration` is the time the server should respond with a cached answer instead of reauthenticating the user, in seconds
+-   `cache_per_rhost`, if activated, signals that caching should take place per remote host, so that connecting from a different IP address requires reauthentication
 -   `verify` alternative SSL CA, for debug purposes
 
 ## Locking yourself out

--- a/pam-weblogin.conf.sample
+++ b/pam-weblogin.conf.sample
@@ -3,4 +3,5 @@ token = Bearer <replace with SRAM API TOKEN for your service>
 retries = 3
 attribute = email
 cache_duration = 30
+#cache_per_rhost
 verify = /etc/ssl/ca.crt

--- a/server/weblogin_daemon.py
+++ b/server/weblogin_daemon.py
@@ -128,7 +128,7 @@ def start():
     user_id = data.get('user_id')
     rhost = data.get('rhost')
     cache_per_rhost = data.get('cache_per_rhost')
-    cache_id = user_id + ',' + rhost if cache_per_rhost else user_id
+    cache_id = (user_id, rhost) if cache_per_rhost else (user_id, None)
     attribute = data.get('attribute')
     cache_duration = data.get('cache_duration', 0)
     new_session_id = session_id()

--- a/src/config.c
+++ b/src/config.c
@@ -101,6 +101,7 @@ Config *getConfig(const char *filename)
 	cfg->token = NULL;
 	cfg->attribute = NULL;
 	cfg->cache_duration = DEFAULT_CACHE_DURATION;
+	cfg->cache_per_rhost = false;
 	cfg->retries = DEFAULT_RETRIES;
 	cfg->pam_user = false;
 
@@ -138,11 +139,16 @@ Config *getConfig(const char *filename)
 			char *val = strchr(key, '=');
 			if (val == NULL)
 			{
-				/* Check for bare pam_user config */
+				/* Check for bare boolean flags in config */
 				if (!strcmp(key, "pam_user"))
 				{
 					cfg->pam_user = true;
 					log_message(LOG_DEBUG, "pam_user");
+				}
+				else if (!strcmp(key, "cache_per_rhost"))
+				{
+					cfg->cache_per_rhost = true;
+					log_message(LOG_DEBUG, "cache_per_rhost");
 				}
 				else
 				{

--- a/src/config.h
+++ b/src/config.h
@@ -12,6 +12,7 @@ typedef struct
 	char *attribute;
 	bool pam_user;
 	unsigned int cache_duration;
+	bool cache_per_rhost;
 	unsigned int retries;
 } Config;
 

--- a/src/pam_weblogin.c
+++ b/src/pam_weblogin.c
@@ -49,6 +49,13 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh, UNUSED int flags, int arg
 		log_message(LOG_ERR, "Error getting user");
 		return PAM_SYSTEM_ERR;
 	}
+	/* Get RHOST. This should always be valid since this PAM module is used with SSH. */
+	const char *rhost;
+	if (pam_get_item(pamh, PAM_RHOST, (const void **)(&rhost)) != PAM_SUCCESS || !rhost)
+	{
+		log_message(LOG_ERR, "Error getting rhost");
+		return PAM_SYSTEM_ERR;
+	}
 
         /* Check if debug argument was given */
 	if (argc == 2 && strcmp(argv[1], "debug") == 0)
@@ -90,12 +97,12 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh, UNUSED int flags, int arg
 	char *data = NULL;
 	if (!cfg->pam_user) // We check local user against remote user based on attribute
 	{
-		data = str_printf("{\"user_id\":\"%s\",\"attribute\":\"%s\",\"cache_duration\":\"%d\",\"GIT_COMMIT\":\"%s\",\"JSONPARSER_GIT_COMMIT\":\"%s\"}",
-				username, cfg->attribute, cfg->cache_duration, TOSTR(GIT_COMMIT), TOSTR(JSONPARSER_GIT_COMMIT));
+		data = str_printf("{\"user_id\":\"%s\",\"attribute\":\"%s\",\"rhost\":\"%s\",\"cache_duration\":\"%d\",\"cache_per_rhost\":\"%s\",\"GIT_COMMIT\":\"%s\",\"JSONPARSER_GIT_COMMIT\":\"%s\"}",
+				username, cfg->attribute, rhost, cfg->cache_duration, cfg->cache_per_rhost ? "true" : "false", TOSTR(GIT_COMMIT), TOSTR(JSONPARSER_GIT_COMMIT));
 	} else // We get local user from remote user based on attribute
 	{
-		data = str_printf("{\"attribute\":\"%s\",\"cache_duration\":\"%d\",\"GIT_COMMIT\":\"%s\",\"JSONPARSER_GIT_COMMIT\":\"%s\"}",
-				cfg->attribute, cfg->cache_duration, TOSTR(GIT_COMMIT), TOSTR(JSONPARSER_GIT_COMMIT));
+		data = str_printf("{\"attribute\":\"%s\",\"rhost\":\"%s\",\"cache_duration\":\"%d\",\"cache_per_rhost\":\"%s\",\"GIT_COMMIT\":\"%s\",\"JSONPARSER_GIT_COMMIT\":\"%s\"}",
+				cfg->attribute, rhost, cfg->cache_duration, cfg->cache_per_rhost ? "true" : "false", TOSTR(GIT_COMMIT), TOSTR(JSONPARSER_GIT_COMMIT));
 	}
 
 	/* Request auth session_id/challenge */

--- a/src/pam_weblogin.c
+++ b/src/pam_weblogin.c
@@ -86,6 +86,7 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh, UNUSED int flags, int arg
 	log_message(LOG_INFO, "cfg->cache_duration: '%d'\n", cfg->cache_duration);
 	log_message(LOG_INFO, "cfg->retries: '%d'\n", cfg->retries);
 */
+	log_message(LOG_INFO, "Starting for user %s from %s", username, rhost);
 
 	authorization = str_printf("Authorization: %s", cfg->token);
 

--- a/tests/pam-weblogin.conf_1
+++ b/tests/pam-weblogin.conf_1
@@ -8,6 +8,7 @@ retries = 3
 attribute = uid
  # cache_duration=60
 cache_duration=60
+#cache_per_rhost
 #pam_user
 pam_user
 nonsense

--- a/tests/pam-weblogin.conf_2
+++ b/tests/pam-weblogin.conf_2
@@ -8,6 +8,7 @@ retries = 3
 attribute = uid
  # cache_duration=60
 cache_duration=0
+cache_per_rhost
 #pam_user
 pam_user
 nonsense

--- a/tests/test_config.c
+++ b/tests/test_config.c
@@ -20,6 +20,7 @@ START_TEST (test_getConfig_1)
 	ck_assert_int_eq(cfg->retries, 3);
 	ck_assert_str_eq(cfg->attribute, "uid");
 	ck_assert_int_eq(cfg->cache_duration, 60);
+	ck_assert(!cfg->cache_per_rhost);
 	ck_assert(cfg->pam_user);
 }
 END_TEST
@@ -35,6 +36,7 @@ START_TEST (test_getConfig_2)
 	ck_assert_int_eq(cfg->retries, 3);
 	ck_assert_str_eq(cfg->attribute, "uid");
 	ck_assert_int_eq(cfg->cache_duration, 0);
+	ck_assert(cfg->cache_per_rhost);
 	ck_assert(cfg->pam_user);
 }
 END_TEST


### PR DESCRIPTION
This allows to cache successful logins per remote host, i.e. per remote IP address.

When active, the pair 'user_id,rhost' will be cached instead of just 'user_id'. This means that if the user connects from a different IP address, a new web-based authentication is required.

Use case:

We use SSH with public_key authentication followed by keyboard-interactive via pam-weblogin. The idea is that a cached web login effectively results in the usual scriptable public_key authentication that users are accustomed to.

Setting the cache duration to several hours means that users have to go through the additional web login typically only once per workday. However, a stolen key pair might then be enough to access the system since an active user will have a cached web login most of the time.

Restricting the caching to the remote IP address solves this problem: a connection from a new IP address requires reauthentication.