### PR TITLE
Fix memory leak when reading group input.

### DIFF
--- a/src/pam_weblogin.c
+++ b/src/pam_weblogin.c
@@ -234,6 +234,7 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh, UNUSED int flags, int arg
 						}
 						char *group_input = tty_input(pamh, PROMPT_GROUP, PAM_PROMPT_ECHO_ON);
 						group = strtol(group_input, &end, 10);
+						free(group_input);
 						range_error = errno == ERANGE;
 						if (group < 1 || group > max_groups || range_error)
 						{


### PR DESCRIPTION
Since this occurs in a potentially endless loop, a malicious user could cause resource exhaustion.